### PR TITLE
Test Maintenance...

### DIFF
--- a/tests/Feature/Livewire/BookingFormTest.php
+++ b/tests/Feature/Livewire/BookingFormTest.php
@@ -150,7 +150,14 @@ it('8 nights is invalid', function () {
 it('summary component appears when form is valid', function () {
     // Arrange
     $this->artisan('db:seed');
-    $selected_date_range = '17 Feb 2025 to 24 Feb 2025';
+    // remember check in must be today onwards
+    $number_of_nights = 7;
+    $check_in_date = now()->format('Y-m-d');
+    $check_out_date = now()->addDays($number_of_nights)->format('Y-m-d');
+    // Create the Date Range String
+    $fromDate = \DateTime::createFromFormat('Y-m-d', $check_in_date);
+    $toDate = \DateTime::createFromFormat('Y-m-d', $check_out_date);
+    $selected_date_range = $fromDate->format('j M Y') . ' to ' . $toDate->format('j M Y');
 
     // Act & Assert
     Livewire::test(BookingComponent::class)
@@ -158,9 +165,11 @@ it('summary component appears when form is valid', function () {
         ->set('room_type_id', 1)
         ->set('selected_date_range', $selected_date_range)
         ->assertSet('selected_date_range', $selected_date_range)
-        ->assertSet('num_nights', 7)
-        ->assertSet('check_in_date', '2025-02-17')
-        ->assertSet('check_out_date', '2025-02-24')
+        ->assertSet('num_nights', $number_of_nights)
+        ->assertSet('check_in_date', $check_in_date)
+        ->assertHasNoErrors('check_in_date')
+        ->assertSet('check_out_date', $check_out_date)
+        ->assertHasNoErrors('check_out_date')
         ->set('num_rooms', 1)
         ->set('num_pax', 1)
         ->assertSeeHtml('Total Cost : ')
@@ -169,10 +178,20 @@ it('summary component appears when form is valid', function () {
         ->assertRedirect(route('pages.booking-form.thank-you'));
 });
 
-it('summary component disappears when form is in-valid', function () {
+it('summary component disappears when form is invalid', function () {
     // Arrange
     $this->artisan('db:seed');
-    $selected_date_range = '17 Feb 2025 to 24 Feb 2025';
+    // remember check in must be today onwards
+    $number_of_nights = 7;
+    $check_in_date = now()->format('Y-m-d');
+    $check_out_date = now()->addDays($number_of_nights)->format('Y-m-d');
+    // Create the Date Range String
+    $fromDate = \DateTime::createFromFormat('Y-m-d', $check_in_date);
+    $toDate = \DateTime::createFromFormat('Y-m-d', $check_out_date);
+    $selected_date_range = $fromDate->format('j M Y') . ' to ' . $toDate->format('j M Y');
+
+    // Make it invalid
+    $num_pax = 2;
 
     // Act & Assert
     Livewire::test(BookingComponent::class)
@@ -180,18 +199,25 @@ it('summary component disappears when form is in-valid', function () {
         ->set('room_type_id', 1)
         ->set('selected_date_range', $selected_date_range)
         ->assertSet('selected_date_range', $selected_date_range)
-        ->assertSet('num_nights', 7)
-        ->assertSet('check_in_date', '2025-02-17')
-        ->assertSet('check_out_date', '2025-02-24')
+        ->assertSet('num_nights', $number_of_nights)
+        ->assertSet('check_in_date', $check_in_date)
+        ->assertSet('check_out_date', $check_out_date)
         ->set('num_rooms', 1)
-        ->set('num_pax', 2)
+        ->set('num_pax', $num_pax)
         ->assertDontSeeLivewire(BookingSummary::class);
 });
 
 it('summary component appears only when notes is filled with pax is 2', function () {
     // Arrange
     $this->artisan('db:seed');
-    $selected_date_range = '17 Feb 2025 to 24 Feb 2025';
+    // remember check in must be today onwards
+    $number_of_nights = 7;
+    $check_in_date = now()->format('Y-m-d');
+    $check_out_date = now()->addDays($number_of_nights)->format('Y-m-d');
+    // Create the Date Range String
+    $fromDate = \DateTime::createFromFormat('Y-m-d', $check_in_date);
+    $toDate = \DateTime::createFromFormat('Y-m-d', $check_out_date);
+    $selected_date_range = $fromDate->format('j M Y') . ' to ' . $toDate->format('j M Y');
 
     // Act & Assert
     Livewire::test(BookingComponent::class)
@@ -199,12 +225,17 @@ it('summary component appears only when notes is filled with pax is 2', function
         ->set('room_type_id', 1)
         ->set('selected_date_range', $selected_date_range)
         ->assertSet('selected_date_range', $selected_date_range)
-        ->assertSet('num_nights', 7)
-        ->assertSet('check_in_date', '2025-02-17')
-        ->assertSet('check_out_date', '2025-02-24')
+        ->assertSet('num_nights', $number_of_nights)
+        ->assertSet('check_in_date', $check_in_date)
+        ->assertHasNoErrors('check_in_date')
+        ->assertSet('check_out_date', $check_out_date)
+        ->assertHasNoErrors('check_out_date')
         ->set('num_rooms', 2)
+        ->assertSet('num_rooms', 2)
         ->set('num_pax', 2)
+        ->assertSet('num_pax', 2)
         ->set('notes', 'This is a note')
+        ->assertSet('notes', 'This is a note')
         ->assertSeeHtml('Total Cost : ')
         ->assertSeeLivewire(BookingSummary::class)
         ->call('save')


### PR DESCRIPTION
I'd set a static date string which was working fine YESTERDAY, forgetting that it would cause an invalid check in date the very next day. Added dynamic dates to the tests to fix it.